### PR TITLE
[Refactor] store 최상위 네비게이션 목적지를 단일 모델로 일원화

### DIFF
--- a/feature/store/src/commonMain/kotlin/in/koreatech/business/feature/store/maintab/MainTabScreen.kt
+++ b/feature/store/src/commonMain/kotlin/in/koreatech/business/feature/store/maintab/MainTabScreen.kt
@@ -1,14 +1,5 @@
 package `in`.koreatech.business.feature.store.maintab
 
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Home
-import androidx.compose.material.icons.filled.LocalOffer
-import androidx.compose.material.icons.filled.MoreHoriz
-import androidx.compose.material.icons.filled.Store
-import androidx.compose.material.icons.outlined.Home
-import androidx.compose.material.icons.outlined.LocalOffer
-import androidx.compose.material.icons.outlined.MoreHoriz
-import androidx.compose.material.icons.outlined.Store
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.NavigationDrawerItemDefaults
@@ -23,11 +14,9 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.backhandler.BackHandler
-import androidx.compose.ui.graphics.vector.ImageVector
+import `in`.koreatech.business.feature.store.navigation.StoreDestination
 import `in`.koreatech.business.ui.theme.KoinTheme
 import koreatech.business.designsystem.resources.*
-import koreatech.business.designsystem.resources.Res
-import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 
 @OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
@@ -47,10 +36,10 @@ fun MainTabScreen(
     onDeleteAccount: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    var selectedTab by rememberSaveable { mutableStateOf(MainTabDestination.Dashboard) }
+    var selectedTab by rememberSaveable { mutableStateOf(StoreDestination.TopTab.Dashboard) }
 
-    BackHandler(enabled = selectedTab != MainTabDestination.Dashboard) {
-        selectedTab = MainTabDestination.Dashboard
+    BackHandler(enabled = selectedTab != StoreDestination.TopTab.Dashboard) {
+        selectedTab = StoreDestination.TopTab.Dashboard
     }
 
     val selectedColor = KoinTheme.colors.primary500
@@ -82,7 +71,7 @@ fun MainTabScreen(
     NavigationSuiteScaffold(
         modifier = modifier,
         navigationSuiteItems = {
-            MainTabDestination.entries.forEach { dest ->
+            StoreDestination.TopTab.entries.forEach { dest ->
                 val isSelected = dest == selectedTab
                 item(
                     selected = isSelected,
@@ -100,18 +89,18 @@ fun MainTabScreen(
         }
     ) {
         when (selectedTab) {
-            MainTabDestination.Dashboard -> TabDashboardContent(
+            StoreDestination.TopTab.Dashboard -> TabDashboardContent(
                 onNavigateToInsertStore = onNavigateToInsertStore
             )
-            MainTabDestination.Menu -> TabMenuContent(
+            StoreDestination.TopTab.Menu -> TabMenuContent(
                 onNavigateToMenuEditor = onNavigateToMenuEditor,
                 onNavigateToCategories = onNavigateToCategories
             )
-            MainTabDestination.Events -> TabEventContent(
+            StoreDestination.TopTab.Events -> TabEventContent(
                 onNavigateToEventEditor = onNavigateToEventEditor,
                 onNavigateToEditEvent = onNavigateToEventEdit
             )
-            MainTabDestination.More -> TabMoreContent(
+            StoreDestination.TopTab.More -> TabMoreContent(
                 onNavigateToStoreInfoEdit = onNavigateToStoreInfoEdit,
                 onNavigateToInsertStore = onNavigateToInsertStore,
                 onNavigateToPasswordReset = onNavigateToPasswordReset,
@@ -123,15 +112,4 @@ fun MainTabScreen(
             )
         }
     }
-}
-
-private enum class MainTabDestination(
-    val labelRes: StringResource,
-    val iconFilled: ImageVector,
-    val iconOutlined: ImageVector
-) {
-    Dashboard(Res.string.sidebar_dashboard, Icons.Filled.Home, Icons.Outlined.Home),
-    Menu(Res.string.tab_menu, Icons.Filled.Store, Icons.Outlined.Store),
-    Events(Res.string.tab_events, Icons.Filled.LocalOffer, Icons.Outlined.LocalOffer),
-    More(Res.string.tab_more, Icons.Filled.MoreHoriz, Icons.Outlined.MoreHoriz)
 }

--- a/feature/store/src/commonMain/kotlin/in/koreatech/business/feature/store/navigation/StoreDestination.kt
+++ b/feature/store/src/commonMain/kotlin/in/koreatech/business/feature/store/navigation/StoreDestination.kt
@@ -1,0 +1,51 @@
+package `in`.koreatech.business.feature.store.navigation
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.LocalOffer
+import androidx.compose.material.icons.filled.MoreHoriz
+import androidx.compose.material.icons.filled.Store
+import androidx.compose.material.icons.outlined.Home
+import androidx.compose.material.icons.outlined.LocalOffer
+import androidx.compose.material.icons.outlined.MoreHoriz
+import androidx.compose.material.icons.outlined.Store
+import androidx.compose.ui.graphics.vector.ImageVector
+import koreatech.business.designsystem.resources.*
+import org.jetbrains.compose.resources.StringResource
+
+/**
+ * store 최상위 네비게이션 목적지 단일 모델.
+ *
+ * - [TopTab]: NavigationSuiteScaffold 탭에 노출되는 최상위 탭 4개.
+ *   각 항목은 [labelRes], [iconFilled], [iconOutlined] 를 보유한다.
+ * - [SubSection]: 탭에는 없지만 사이드바에 표시되는 보조 항목
+ *   (Categories, StoreInfo, Theme, Terms, Privacy, OssLicenses).
+ * - [None]: "선택 없음" 센티넬. StoreSubScreenLayout 의 기본값으로 사용된다.
+ */
+sealed interface StoreDestination {
+
+    /** NavigationSuiteScaffold 탭에 노출되는 항목 */
+    enum class TopTab(
+        val labelRes: StringResource,
+        val iconFilled: ImageVector,
+        val iconOutlined: ImageVector
+    ) : StoreDestination {
+        Dashboard(Res.string.sidebar_dashboard, Icons.Filled.Home, Icons.Outlined.Home),
+        Menu(Res.string.tab_menu, Icons.Filled.Store, Icons.Outlined.Store),
+        Events(Res.string.tab_events, Icons.Filled.LocalOffer, Icons.Outlined.LocalOffer),
+        More(Res.string.tab_more, Icons.Filled.MoreHoriz, Icons.Outlined.MoreHoriz)
+    }
+
+    /** 사이드바 전용 보조 항목 (탭 바에는 없음) */
+    enum class SubSection : StoreDestination {
+        Categories,
+        StoreInfo,
+        Theme,
+        Terms,
+        Privacy,
+        OssLicenses
+    }
+
+    /** 선택 없음 센티넬 */
+    data object None : StoreDestination
+}

--- a/feature/store/src/commonMain/kotlin/in/koreatech/business/feature/store/ui/component/StoreSubScreenLayout.kt
+++ b/feature/store/src/commonMain/kotlin/in/koreatech/business/feature/store/ui/component/StoreSubScreenLayout.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import `in`.koreatech.business.feature.store.navigation.StoreDestination
 import `in`.koreatech.business.ui.theme.KoinTheme
 import koreatech.business.designsystem.resources.*
 import koreatech.business.designsystem.resources.Res
@@ -48,19 +49,6 @@ import org.jetbrains.compose.resources.stringResource
 
 private val DESKTOP_BREAKPOINT = 700.dp
 private val SIDEBAR_WIDTH = 260.dp
-
-enum class StoreNavSection {
-    Dashboard,
-    Menu,
-    Categories,
-    Events,
-    StoreInfo,
-    Theme,
-    Terms,
-    Privacy,
-    OssLicenses,
-    None
-}
 
 data class StoreSidebarActions(
     val onNavigateToDashboard: (() -> Unit)? = null,
@@ -83,7 +71,7 @@ data class StoreSidebarActions(
 fun StoreSubScreenLayout(
     onNavigateBack: () -> Unit,
     modifier: Modifier = Modifier,
-    activeSection: StoreNavSection = StoreNavSection.None,
+    activeSection: StoreDestination = StoreDestination.None,
     sidebarActions: StoreSidebarActions = StoreSidebarActions(),
     content: @Composable () -> Unit
 ) {
@@ -135,7 +123,7 @@ fun StoreSubScreenLayout(
                     SidebarNavItem(
                         label = stringResource(Res.string.sidebar_dashboard),
                         icon = Icons.Default.Home,
-                        selected = activeSection == StoreNavSection.Dashboard,
+                        selected = activeSection == StoreDestination.TopTab.Dashboard,
                         onClick = sidebarActions.onNavigateToDashboard
                     )
                     Spacer(Modifier.height(4.dp))
@@ -143,25 +131,25 @@ fun StoreSubScreenLayout(
                     SidebarNavItem(
                         label = stringResource(Res.string.manage_menus_title),
                         icon = Icons.Default.Store,
-                        selected = activeSection == StoreNavSection.Menu,
+                        selected = activeSection == StoreDestination.TopTab.Menu,
                         onClick = sidebarActions.onNavigateToMenu
                     )
                     SidebarSubItem(
                         label = stringResource(Res.string.field_category),
-                        selected = activeSection == StoreNavSection.Categories,
+                        selected = activeSection == StoreDestination.SubSection.Categories,
                         onClick = sidebarActions.onNavigateToCategories
                     )
                     SidebarNavItem(
                         label = stringResource(Res.string.event_management),
                         icon = Icons.Default.LocalOffer,
-                        selected = activeSection == StoreNavSection.Events,
+                        selected = activeSection == StoreDestination.TopTab.Events,
                         onClick = sidebarActions.onNavigateToEvents
                     )
 
                     SidebarNavItem(
                         label = stringResource(Res.string.modify_store_info_title),
                         icon = Icons.Default.Edit,
-                        selected = activeSection == StoreNavSection.StoreInfo,
+                        selected = activeSection == StoreDestination.SubSection.StoreInfo,
                         onClick = sidebarActions.onNavigateToStoreInfo
                     )
 
@@ -170,7 +158,7 @@ fun StoreSubScreenLayout(
                     SidebarNavItem(
                         label = stringResource(Res.string.theme),
                         icon = Icons.Outlined.DarkMode,
-                        selected = activeSection == StoreNavSection.Theme,
+                        selected = activeSection == StoreDestination.SubSection.Theme,
                         onClick = sidebarActions.onNavigateToTheme
                     )
 
@@ -179,19 +167,19 @@ fun StoreSubScreenLayout(
                     SidebarNavItem(
                         label = stringResource(Res.string.service_terms),
                         icon = Icons.Default.Description,
-                        selected = activeSection == StoreNavSection.Terms,
+                        selected = activeSection == StoreDestination.SubSection.Terms,
                         onClick = sidebarActions.onNavigateToTerms
                     )
                     SidebarNavItem(
                         label = stringResource(Res.string.privacy_policy),
                         icon = Icons.Default.Lock,
-                        selected = activeSection == StoreNavSection.Privacy,
+                        selected = activeSection == StoreDestination.SubSection.Privacy,
                         onClick = sidebarActions.onNavigateToPrivacy
                     )
                     SidebarNavItem(
                         label = stringResource(Res.string.oss_licenses),
                         icon = Icons.Default.Info,
-                        selected = activeSection == StoreNavSection.OssLicenses,
+                        selected = activeSection == StoreDestination.SubSection.OssLicenses,
                         onClick = sidebarActions.onNavigateToOssLicenses
                     )
                 }


### PR DESCRIPTION
## Summary
`feature/store` 모듈에 중복 정의되어 있던 store 최상위 네비게이션 목적지 모델(`MainTabDestination`, `StoreNavSection`)을 `StoreDestination` 단일 모델로 일원화하였습니다. 기존 레이아웃 및 렌더링 로직의 변경 없이 데이터 모델 계층의 식별자 정의만 통합하였습니다.

## Test plan
- [x] `./gradlew :feature:store:compileDebugKotlinAndroid` 빌드 성공 확인
- [x] `./gradlew :feature:store:ktlintCheck` 통과 확인