### PR TITLE
[Refactor] StoreSubScreenLayout 700dp 하드코딩 제거 및 WindowSizeClass 적용

### DIFF
--- a/feature/store/src/commonMain/kotlin/in/koreatech/business/feature/store/ui/component/StoreSubScreenLayout.kt
+++ b/feature/store/src/commonMain/kotlin/in/koreatech/business/feature/store/ui/component/StoreSubScreenLayout.kt
@@ -43,11 +43,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import `in`.koreatech.business.feature.store.navigation.StoreDestination
 import `in`.koreatech.business.ui.theme.KoinTheme
+import `in`.koreatech.business.ui.theme.WindowSizeClass
 import koreatech.business.designsystem.resources.*
 import koreatech.business.designsystem.resources.Res
 import org.jetbrains.compose.resources.stringResource
 
-private val DESKTOP_BREAKPOINT = 700.dp
 private val SIDEBAR_WIDTH = 260.dp
 
 data class StoreSidebarActions(
@@ -76,7 +76,8 @@ fun StoreSubScreenLayout(
     content: @Composable () -> Unit
 ) {
     BoxWithConstraints(modifier = modifier.fillMaxSize()) {
-        if (maxWidth < DESKTOP_BREAKPOINT) {
+        val sizeClass = WindowSizeClass.of(maxWidth)
+        if (sizeClass == WindowSizeClass.Compact) {
             content()
             return@BoxWithConstraints
         }


### PR DESCRIPTION
## Summary
`StoreSubScreenLayout` 내 하드코딩된 `700.dp` 브레이크포인트를 `WindowSizeClass` API로 치환하여 레이아웃 어댑티브 규칙을 앱 전역 컨벤션과 정렬하였습니다.

## Test plan
- [x] 컴포넌트 레이아웃 분기 로직 정상 동작 확인
- [x] 600dp 이상에서 사이드바 표시 확인

## 이슈 번호
#11

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [x] 리팩토링 (기능 수정 X, API 수정 X)

## 작업사항의 상세한 설명
- `DESKTOP_BREAKPOINT = 700.dp` 상수 제거
- `maxWidth < 700.dp` 직접 비교 로직을 `WindowSizeClass.of(maxWidth) == WindowSizeClass.Compact` 조건으로 변경
- 로컬 `BoxWithConstraints` 측정 기준을 유지하여 부모 컨테이너 너비 기반의 어댑티브 레이아웃 보존

## 논의 사항
(없음)

## 스크린샷
(UI 변경 없음)

## 추가내용
- [x] develop 브랜치 대상