### PR TITLE
[Refactor] DesktopAppShell 960dp 매직 넘버를 WindowSizeClass 기반 분기로 치환

### DIFF
--- a/core/ui/src/commonMain/kotlin/in/koreatech/business/ui/component/DesktopAppShell.kt
+++ b/core/ui/src/commonMain/kotlin/in/koreatech/business/ui/component/DesktopAppShell.kt
@@ -2,7 +2,6 @@ package `in`.koreatech.business.ui.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -20,6 +19,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import `in`.koreatech.business.ui.theme.KoinTheme
+import `in`.koreatech.business.ui.theme.WindowSizeClass
 import koreatech.business.designsystem.resources.Res
 import koreatech.business.designsystem.resources.desktop_shell_role
 import koreatech.business.designsystem.resources.desktop_shell_tagline1
@@ -34,13 +34,8 @@ fun DesktopAppShell(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit
 ) {
-    BoxWithConstraints(modifier = modifier.fillMaxSize()) {
-        if (maxWidth < 960.dp) {
-            content()
-            return@BoxWithConstraints
-        }
-
-        Row(modifier = Modifier.fillMaxSize()) {
+    if (KoinTheme.windowSizeClass is WindowSizeClass.Expanded) {
+        Row(modifier = modifier.fillMaxSize()) {
             BrandPanel(modifier = Modifier.width(340.dp).fillMaxHeight())
 
             Box(
@@ -51,6 +46,10 @@ fun DesktopAppShell(
             ) {
                 content()
             }
+        }
+    } else {
+        Box(modifier = modifier.fillMaxSize()) {
+            content()
         }
     }
 }


### PR DESCRIPTION
## Summary
`core/ui` 모듈의 `DesktopAppShell.kt`에서 기존 `BoxWithConstraints`와 하드코딩된 `960.dp` 매직 넘버를 제거했습니다. 대신, 선행 이슈(#10)에서 도입된 `KoinTheme.windowSizeClass`를 사용하여 `WindowSizeClass.Expanded` 여부에 따라 브랜드 패널을 동적으로 노출하도록 리팩토링했습니다.

## Test plan
- [x] `./gradlew ktlintFormat` 실행을 통한 코드 스타일 정리
- [x] `./gradlew ktlintCheck` 실행을 통한 린트 검증
- [x] `./gradlew :core:ui:compileDebugKotlinAndroid` 실행을 통한 Android 변형 빌드 확인

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [x] 리팩토링 (기능 수정 X, API 수정 X)

## 작업사항의 상세한 설명
- `DesktopAppShell.kt` 내 `BoxWithConstraints` 제거
- `maxWidth < 960.dp` 조건 분기를 `KoinTheme.windowSizeClass is WindowSizeClass.Expanded`로 교체 (이에 따라 기준 임계값이 960dp에서 840dp로 변경됨)
- 좁은 창(`!Expanded`)인 경우 `Box`를 통해 콘텐츠 표시, `Expanded`인 경우 `Row`로 `BrandPanel`과 콘텐츠 분리
- 불필요한 import 제거 및 `WindowSizeClass` 관련 import 추가

## 논의 사항
(없음)

## 스크린샷
(UI 변경 없음)

## 추가내용
- [x] 대상 브랜치가 develop 임을 확인