### PR TITLE
[Refactor] SignInScreen 하드코딩 분기를 WindowSizeClass API로 개선

### DIFF
--- a/feature/auth/src/commonMain/kotlin/in/koreatech/business/feature/signin/SignInScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/in/koreatech/business/feature/signin/SignInScreen.kt
@@ -47,6 +47,7 @@ import `in`.koreatech.business.ui.component.KoinTextFieldAlert
 import `in`.koreatech.business.ui.component.KoinTextFieldAlertType
 import `in`.koreatech.business.ui.component.PhoneVisualTransformation
 import `in`.koreatech.business.ui.theme.KoinTheme
+import `in`.koreatech.business.ui.theme.WindowSizeClass
 import koreatech.business.designsystem.resources.*
 import koreatech.business.designsystem.resources.Res
 import org.jetbrains.compose.resources.stringResource
@@ -102,9 +103,9 @@ internal fun SignInScreenImpl(
             .imePadding()
             .verticalScroll(rememberScrollState())
     ) {
-        val isDesktop = maxWidth >= 600.dp
+        val sizeClass = WindowSizeClass.of(maxWidth)
         val formMaxWidth = (maxWidth * 0.6f).coerceIn(360.dp, 560.dp)
-        val columnModifier = if (isDesktop) {
+        val columnModifier = if (sizeClass !is WindowSizeClass.Compact) {
             Modifier
                 .widthIn(max = formMaxWidth)
                 .align(Alignment.Center)
@@ -117,7 +118,7 @@ internal fun SignInScreenImpl(
         }
 
         Column(modifier = columnModifier) {
-            if (!isDesktop) {
+            if (sizeClass is WindowSizeClass.Compact) {
                 // Top spacer (mobile only)
                 Spacer(modifier = Modifier.height(32.dp))
             }


### PR DESCRIPTION
## Summary
SignInScreen.kt에서 사용되던 하드코딩된 레이아웃 분기(`maxWidth >= 600.dp`)를 프로젝트의 공통 `WindowSizeClass` API(`sizeClass !is WindowSizeClass.Compact`)를 사용하도록 리팩토링하였습니다.

## 이슈 번호
#13

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [x] 리팩토링 (기능 수정 X, API 수정 X)

## 작업사항의 상세한 설명
- `SignInScreen.kt` 내 `BoxWithConstraints` 블록에서 사용되던 `isDesktop` 계산식을 제거하고, `WindowSizeClass.of(maxWidth)`를 사용하여 `sizeClass`를 가져오도록 수정하였습니다.
- `600dp`를 기준으로 하던 기존 동작을 보존하기 위해 `WindowSizeClass.Compact`가 아닌 경우(`!is`)에 넓은 화면 레이아웃을 적용하도록 변경하였습니다.
- 필요한 `WindowSizeClass` 클래스를 import 하였습니다.
- 기존의 `formMaxWidth` 계산 및 기타 레이아웃 modifiers는 변경하지 않아 시각적으로 동일한 결과를 유지합니다.

## 논의 사항
(없음)

## 스크린샷
(UI 변경 없음)

## 추가내용
- [x] develop 브랜치 대상 작업