### PR TITLE
[Refactor] 크기 클래스 전환 시 네비게이션 상태(선택 탭/백스택) 보존 구조 정비

### DIFF
--- a/feature/store/src/commonMain/kotlin/in/koreatech/business/feature/store/maintab/MainTabScreen.kt
+++ b/feature/store/src/commonMain/kotlin/in/koreatech/business/feature/store/maintab/MainTabScreen.kt
@@ -1,5 +1,7 @@
 package `in`.koreatech.business.feature.store.maintab
 
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.NavigationDrawerItemDefaults
@@ -37,6 +39,11 @@ fun MainTabScreen(
     modifier: Modifier = Modifier
 ) {
     var selectedTab by rememberSaveable { mutableStateOf(StoreDestination.TopTab.Dashboard) }
+
+    val dashboardScrollState = rememberScrollState()
+    val moreScrollState = rememberScrollState()
+    val menuListState = rememberLazyListState()
+    val eventsListState = rememberLazyListState()
 
     BackHandler(enabled = selectedTab != StoreDestination.TopTab.Dashboard) {
         selectedTab = StoreDestination.TopTab.Dashboard
@@ -90,15 +97,18 @@ fun MainTabScreen(
     ) {
         when (selectedTab) {
             StoreDestination.TopTab.Dashboard -> TabDashboardContent(
-                onNavigateToInsertStore = onNavigateToInsertStore
+                onNavigateToInsertStore = onNavigateToInsertStore,
+                scrollState = dashboardScrollState
             )
             StoreDestination.TopTab.Menu -> TabMenuContent(
                 onNavigateToMenuEditor = onNavigateToMenuEditor,
-                onNavigateToCategories = onNavigateToCategories
+                onNavigateToCategories = onNavigateToCategories,
+                listState = menuListState
             )
             StoreDestination.TopTab.Events -> TabEventContent(
                 onNavigateToEventEditor = onNavigateToEventEditor,
-                onNavigateToEditEvent = onNavigateToEventEdit
+                onNavigateToEditEvent = onNavigateToEventEdit,
+                listState = eventsListState
             )
             StoreDestination.TopTab.More -> TabMoreContent(
                 onNavigateToStoreInfoEdit = onNavigateToStoreInfoEdit,
@@ -108,7 +118,8 @@ fun MainTabScreen(
                 onNavigateToServiceTerms = onNavigateToServiceTerms,
                 onNavigateToOSSLicenses = onNavigateToOSSLicenses,
                 onSignOut = onSignOut,
-                onDeleteAccount = onDeleteAccount
+                onDeleteAccount = onDeleteAccount,
+                scrollState = moreScrollState
             )
         }
     }

--- a/feature/store/src/commonMain/kotlin/in/koreatech/business/feature/store/maintab/TabDashboardContent.kt
+++ b/feature/store/src/commonMain/kotlin/in/koreatech/business/feature/store/maintab/TabDashboardContent.kt
@@ -2,6 +2,7 @@
 
 package `in`.koreatech.business.feature.store.maintab
 
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -17,7 +18,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -71,6 +71,7 @@ import org.orbitmvi.orbit.compose.collectAsState
 @Composable
 fun TabDashboardContent(
     onNavigateToInsertStore: () -> Unit,
+    scrollState: ScrollState,
     viewModel: StoreDashboardViewModel = koinViewModel()
 ) {
     val uiState by viewModel.collectAsState()
@@ -125,7 +126,7 @@ fun TabDashboardContent(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .verticalScroll(rememberScrollState())
+                .verticalScroll(scrollState)
                 .padding(16.dp)
         ) {
             // 매장 셀렉터 (다중 매장)

--- a/feature/store/src/commonMain/kotlin/in/koreatech/business/feature/store/maintab/TabEventContent.kt
+++ b/feature/store/src/commonMain/kotlin/in/koreatech/business/feature/store/maintab/TabEventContent.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -71,6 +72,7 @@ import org.orbitmvi.orbit.compose.collectAsState
 @Composable
 fun TabEventContent(
     onNavigateToEventEditor: (storeId: String) -> Unit,
+    listState: LazyListState,
     onNavigateToEditEvent: (storeId: String, eventId: String) -> Unit = { _, _ -> },
     viewModel: EventTabViewModel = koinViewModel()
 ) {
@@ -164,7 +166,8 @@ fun TabEventContent(
                         onToggleExpand = viewModel::toggleExpanded,
                         onEditEvent = { eventId ->
                             if (!storeId.isNullOrBlank()) onNavigateToEditEvent(storeId, eventId)
-                        }
+                        },
+                        listState = listState
                     )
                 }
             }
@@ -318,12 +321,14 @@ private fun EventList(
     expandedIds: Set<Int>,
     onToggleSelection: (Int) -> Unit,
     onToggleExpand: (Int) -> Unit,
-    onEditEvent: (String) -> Unit
+    onEditEvent: (String) -> Unit,
+    listState: LazyListState
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 12.dp, bottom = 96.dp),
-        verticalArrangement = Arrangement.spacedBy(10.dp)
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+        state = listState
     ) {
         items(events, key = { it.id }) { event ->
             EventCard(

--- a/feature/store/src/commonMain/kotlin/in/koreatech/business/feature/store/maintab/TabMenuContent.kt
+++ b/feature/store/src/commonMain/kotlin/in/koreatech/business/feature/store/maintab/TabMenuContent.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -62,6 +63,7 @@ import org.orbitmvi.orbit.compose.collectAsState
 fun TabMenuContent(
     onNavigateToMenuEditor: (storeId: String, menuId: String?) -> Unit,
     onNavigateToCategories: (storeId: String) -> Unit,
+    listState: LazyListState,
     viewModel: ManageMenusViewModel = koinViewModel()
 ) {
     val uiState by viewModel.collectAsState()
@@ -127,7 +129,8 @@ fun TabMenuContent(
                 else -> {
                     MenuList(
                         categories = uiState.categories,
-                        onClickMenu = { menu -> onNavigateToMenuEditor(storeId, menu.id.toString()) }
+                        onClickMenu = { menu -> onNavigateToMenuEditor(storeId, menu.id.toString()) },
+                        listState = listState
                     )
                 }
             }
@@ -183,11 +186,13 @@ private fun CategoryChipButton(onClick: () -> Unit) {
 @Composable
 private fun MenuList(
     categories: List<MenuCategory>,
-    onClickMenu: (MenuItem) -> Unit
+    onClickMenu: (MenuItem) -> Unit,
+    listState: LazyListState
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(top = 12.dp, bottom = 88.dp)
+        contentPadding = PaddingValues(top = 12.dp, bottom = 88.dp),
+        state = listState
     ) {
         categories.forEach { category ->
             item(key = "header_${category.id}") {

--- a/feature/store/src/commonMain/kotlin/in/koreatech/business/feature/store/maintab/TabMoreContent.kt
+++ b/feature/store/src/commonMain/kotlin/in/koreatech/business/feature/store/maintab/TabMoreContent.kt
@@ -2,6 +2,7 @@
 
 package `in`.koreatech.business.feature.store.maintab
 
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -16,7 +17,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -75,6 +75,7 @@ fun TabMoreContent(
     onNavigateToOSSLicenses: () -> Unit,
     onSignOut: () -> Unit,
     onDeleteAccount: () -> Unit,
+    scrollState: ScrollState,
     viewModel: SettingsViewModel = koinViewModel(),
     dashboardViewModel: StoreDashboardViewModel = koinViewModel()
 ) {
@@ -134,7 +135,7 @@ fun TabMoreContent(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .verticalScroll(rememberScrollState())
+                .verticalScroll(scrollState)
                 .padding(top = 12.dp, bottom = 24.dp)
         ) {
             // 사장님 헤더 카드


### PR DESCRIPTION
## 이슈 번호
#15

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [x] 리팩토링 (기능 수정 X, API 수정 X)

## 작업사항의 상세한 설명
`MainTabScreen`의 탭 전환 시 `when` 분기로 인해 선택되지 않은 탭의 Composable이 composition에서 제거되어, 각 탭의 스크롤 위치 및 목록 상태가 소멸하는 문제를 해결했습니다.

- 각 탭의 스크롤/목록 상태(`ScrollState`, `LazyListState`)를 `MainTabScreen`으로 호이스팅하여 탭 전환 중에도 상태가 소멸하지 않도록 구현했습니다.
- CMP 1.9.0의 API 제한(deprecated된 `rememberSaveable(key = ...)` 사용 금지)을 준수하여, 커스텀 key 없이 위치 기반으로 상태를 관리합니다.
- `MainTabScreen`에 호이스팅된 상태를 각 탭 Composable에 주입하도록 시그니처를 수정했습니다.
- Kotlin 파라미터 순서 정리 및 import 구문 정렬 등 코드 컨벤션 보완을 완료했습니다.

## 논의 사항
(없음)

## 스크린샷
(UI 변경 없음)

## 추가내용
- [x] develop 브랜치 대상

## Summary
`MainTabScreen`의 탭 전환 시 Composable이 소멸하며 초기화되던 각 탭의 스크롤 위치 및 목록 상태를 호이스팅하여 보존 구조를 정비했습니다.

## Test plan
- [x] 수동 검증: JVM Desktop 창 리사이즈 및 Android 화면 회전/폴더블 전환 시 탭 전환 후에도 스크롤 위치 및 선택 탭 보존 확인
- [x] 컴파일 검증: `./gradlew :feature:store:compileDebugKotlinAndroid` 성공 확인
- [x] 코드 품질 검증: `./gradlew :feature:store:detekt` 및 `ktlintCheck` 통과 확인

## Checklist
- [x] PR 제목 컨벤션 준수
- [x] 이슈 번호 연결
- [x] 작업사항 체크
- [x] detekt 및 ktlint 검사 통과
- [x] 기능 동작 검증 완료